### PR TITLE
Code cleanup to get rid of warnings from gcc (7.3, SUSE Linux)

### DIFF
--- a/src/galasm.c
+++ b/src/galasm.c
@@ -164,16 +164,18 @@ int AssemblePldFile(char *file, struct Config *cfg)
 	int  	num_of_col,fsize;
 
         {
-            fsize = FileSize((UBYTE *)file);
+            fsize = FileSize(file);
 
 		if((fbuff = malloc(fsize)))
             {
-                if ((ReadFile((UBYTE *)file, fsize, fbuff)))
+                if ((ReadFile(file, fsize, fbuff)))
                 {
                     actptr  = fbuff;
                     buffend = fbuff+fsize;
                     linenum = 1;
 
+/* This code generates a warning about exceeding array bounds */
+#if	0
                     for (n = 0; n < sizeof(Jedec); n++)
                     {                            /* init. JEDEC structure */
                         if (n < LOGIC22V10_SIZE)
@@ -181,8 +183,10 @@ int AssemblePldFile(char *file, struct Config *cfg)
                         else
                             Jedec.GALLogic[n] = 0;         /* clear ACW... */
                     }
-
-
+#endif
+/* I think this is what is intended: GALLogic is set to 1s, rest is cleared */
+                    memset(&Jedec, 0, sizeof(Jedec));
+                    memset(Jedec.GALLogic, 1, sizeof(Jedec.GALLogic));
 
                     for (n = 0; n < 12; n++)
                     {                              /* clear OLMC structure */
@@ -1641,7 +1645,7 @@ void IsPinName(UBYTE *pinnames, int numofpins)
         n++;
     }
 
-    if (n)
+    if (n) {
         if ((n == 2 ) && !strncmp((char *)oldactptr, "NC", (size_t)2))
             actPin.p_Pin = NC_PIN;                      /* NC pin*/
         else
@@ -1661,6 +1665,7 @@ void IsPinName(UBYTE *pinnames, int numofpins)
                     break;
                 }
             }
+    }
 }
 
 

--- a/src/galasm.h
+++ b/src/galasm.h
@@ -252,7 +252,7 @@ void  Is_AR_SP(UBYTE *ptr);
 /* support.c */
 char *GetBaseName(char *filename);
 int FileSize(char *filename);
-int   ReadFile(char *filename, int filesize, char *filebuff);
+int   ReadFile(char *filename, int filesize, UBYTE *filebuff);
 int   AddByte(struct ActBuffer *buff, UBYTE code);
 int   AddString(struct ActBuffer *buff, UBYTE *strnptr);
 void  IncPointer(struct ActBuffer *buff);

--- a/src/jedec.c
+++ b/src/jedec.c
@@ -197,7 +197,7 @@ int FuseChecksum(int galtype)
  
 int MakeJedecBuff(struct ActBuffer buff, int galtype, struct Config *cfg)
 {
-    UBYTE   mystrng[10];
+    UBYTE   mystrng[16];
     struct  ActBuffer buff2;
     int     n, m, bitnum, bitnum2, flag;
     int     MaxFuseAdr = 0, RowSize = 0, XORSize = 0;

--- a/src/support.c
+++ b/src/support.c
@@ -103,7 +103,7 @@ int FileSize(char *filename)
 **
 ******************************************************************************/
 
-int ReadFile(char *filename, int filesize, char *filebuff)
+int ReadFile(char *filename, int filesize, UBYTE *filebuff)
 {
     int  actlen;
     FILE *fp;


### PR DESCRIPTION
Most important are increasing mystrng size, and clearing the Jedec struct in a better way.

I have compared the output from all the examples before and after the change and they are identical. I have also compared the output from all the examples with the original examples (from version 2.0) and they are identical except for NL -> CR NL, the Used Program and GAL-Assembler header lines, and the file checksum.