### PR TITLE
Fix a bug in GetBaseName function

### DIFF
--- a/src/support.c
+++ b/src/support.c
@@ -46,6 +46,7 @@ char *GetBaseName(char *filename)
 
 	if((p = (char *)malloc(n+5)))
 	{
+		memset(p, ' ', n+4);
 		strncpy(p, filename, n); 
 		p[n+4] = '\0';
 


### PR DESCRIPTION
The implementation allocates memory for the base name result. And puts a null char at the end of the string. But it doesn't take into account that malloc can generate a memory slice containing null chars. When this happens, the returned string is just the base name, without space for the file extensions.

For example, when input file is `decoding.pld`, the generated files are `deco.jed`, etc. I could reproduce this at least in MacOSX 10.14.5. 

The fix just uses `memset()` to fill the string with blank spaces to ensure no null characters are present other than the one inserted at the end.