### PR TITLE
Support for Windows AND fix checksum calculations

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2,6 +2,7 @@
 
 TARGET		= galasm
 OBJS		= galasm.o support.o jedec.o localize.o
+CC          = gcc
 
 CFLAGS		= -Wall -O2 -Iinclude -I.
 

--- a/src/galasm.c
+++ b/src/galasm.c
@@ -2321,6 +2321,7 @@ int main(int argc, char *argv[])
 	cfg.GenPin 	 	= TRUE;
 	cfg.JedecSecBit 	= FALSE;
 	cfg.JedecFuseChk 	= FALSE;
+	cfg.ForceCRLF		= FALSE;
 
 	p = argv[1];
 
@@ -2358,15 +2359,21 @@ int main(int argc, char *argv[])
 				cfg.JedecFuseChk = TRUE;
 			break;
 
+			case 'w':
+			case 'W':
+				cfg.ForceCRLF = TRUE;
+			break;
+
 			case 'h':
 			case 'H':
 			case '?':
-	    		printf("Usage:\nGALasm [-scfpa] <filename>\n");
+				printf("Usage:\nGALasm [-scfpaw] <filename>\n");
 				printf(	"-s Enable security fuse\n"
 						"-c Do not create the .chp file\n"
 						"-f Do not create the .fus file\n"
 						"-p Do not create the .pin file\n"
-						"-a Restrict checksum to the fuse array only\n");
+						"-a Restrict checksum to the fuse array only\n"
+						"-w Force <CR><LF> line endings for .jed file overriding platform default\n");
 				return(0);
 
       		case '-': 
@@ -2397,7 +2404,7 @@ int main(int argc, char *argv[])
   	if(argc != 2) 
 	{
 		usage:
-    		printf("Usage:\nGALasm [-scfpa] <filename>\n");
+			printf("Usage:\nGALasm [-scfpaw] <filename>\n");
 			printf("Type GALasm -h for help\n");
 		return(5);
   	}

--- a/src/galasm.c
+++ b/src/galasm.c
@@ -2303,6 +2303,7 @@ void AsmError(int errornum, int pinnum)
 ** -f Disable .fus file output
 ** -p Disable .pin file output
 ** -a Restrict checksum to the fuse array only
+** -w Force <CR><LF> line endings for .jed file overriding platform default
 **
 **
 ** 

--- a/src/galasm.h
+++ b/src/galasm.h
@@ -165,6 +165,7 @@ struct  Config
     BOOL GenPin;           /* generate pin file?         */
     BOOL JedecSecBit;      /* set security bit in JEDEC? */
     BOOL JedecFuseChk;     /* calc. fuse checksum?       */ /* azummo: if false, file checksum will be generated */
+    BOOL ForceCRLF;        /* windows line endings?      */
 };
 
 

--- a/src/galasm.h
+++ b/src/galasm.h
@@ -262,10 +262,10 @@ char *GetGALName(int galtype);
 void  ErrorReq(int errornum);
 
 /* Jedec.c */
-int   FileChecksum(char* filename, unsigned* pchecksum);
-int   FuseChecksum(int galtype);
-int   MakeJedecBuff(struct ActBuffer buff, int galtype, struct Config *cfg);
-void  WriteJedecFile(char *filename, int galtype, struct Config *cfg);
+int      FileChecksum(char* filename, unsigned* pchecksum);
+unsigned FuseChecksum(int galtype);
+int      MakeJedecBuff(struct ActBuffer buff, int galtype, struct Config *cfg);
+void     WriteJedecFile(char *filename, int galtype, struct Config *cfg);
 
 
 /* EOF */

--- a/src/galasm.h
+++ b/src/galasm.h
@@ -262,7 +262,7 @@ char *GetGALName(int galtype);
 void  ErrorReq(int errornum);
 
 /* Jedec.c */
-int   FileChecksum(struct ActBuffer buff);
+int   FileChecksum(char* filename, unsigned* pchecksum);
 int   FuseChecksum(int galtype);
 int   MakeJedecBuff(struct ActBuffer buff, int galtype, struct Config *cfg);
 void  WriteJedecFile(char *filename, int galtype, struct Config *cfg);

--- a/src/jedec.c
+++ b/src/jedec.c
@@ -82,10 +82,12 @@ int FileChecksum(char *filename, unsigned *pchecksum)
 **          structure.
 ******************************************************************************/
 
-int FuseChecksum(int galtype)
+unsigned FuseChecksum(int galtype)
 {
-    int     checksum, byte, n;
-    BYTE    *ptr, *ptrXOR, *ptrS1;
+    int      n;
+    unsigned checksum;
+    UBYTE    byte;
+    BYTE     *ptr, *ptrXOR, *ptrS1;
 
 
 
@@ -93,7 +95,9 @@ int FuseChecksum(int galtype)
     ptrXOR = &Jedec.GALXOR[0];
     ptrS1  = &Jedec.GALS1[0];
 
-    n = checksum = byte = 0;
+    n        = 0;
+    checksum = 0;
+    byte     = 0;
 
     for (;;)
     {
@@ -186,14 +190,14 @@ int FuseChecksum(int galtype)
 
         if (!((n + 9)%8))
         {
-            checksum += byte;
+            checksum = (checksum + byte) % 0x10000;
             byte = 0;
         }
 
         n++;
     }
 
-    checksum += byte;
+    checksum = (checksum + byte) % 0x10000;
 
     return(checksum);
 }

--- a/src/jedec.c
+++ b/src/jedec.c
@@ -223,7 +223,6 @@ unsigned FuseChecksum(int galtype)
 int MakeJedecBuff(struct ActBuffer buff, int galtype, struct Config *cfg)
 {
     UBYTE   mystrng[16];
-    struct  ActBuffer buff2;
     int     n, m, bitnum, bitnum2, flag;
     int     MaxFuseAdr = 0, RowSize = 0, XORSize = 0;
 
@@ -255,9 +254,6 @@ int MakeJedecBuff(struct ActBuffer buff, int galtype, struct Config *cfg)
                  break;
     }
 
-
-
-    buff2 = buff;
 
     if (!cfg->JedecFuseChk)
         if (AddString(&buff, (UBYTE *)"\2\n"))          /* <STX> */

--- a/src/support.c
+++ b/src/support.c
@@ -73,13 +73,14 @@ int FileSize(char *filename)
 {
 	FILE *fp;
 
-	int size;
+	int size = 0;
 
 	if((fp = fopen(filename, "r")))
 	{
-		fseek(fp, 0, SEEK_END);
-
-		size = ftell(fp);
+		while (fgetc(fp) != EOF)
+		{
+			size++;
+		}
 
 		fclose(fp);
 	}


### PR DESCRIPTION
This pull request addresses issues related to Windows vs. Unix and also checksum calculations.

Issues addressed (tested on Mac and on Windows):

1 .jed file checksum was incorrect on Mac and on Windows; reported incorrect by the Minipro programmer
  * Cause: Checksum calculation was using LF line endings not the CR LF line endings as written to the file.
  * Fix: Write file and then read back file in binary mode to calculate checksum. This approach will work cross-platform - including Windows, where text files translate LF to CR LF. Additionally, I added a new -w option to force Windows line endings in the output .jed file. Without this option the line endings will follow the default of the platform (which would be the most expected behavior for a utility.)
  * Verification: Before this fix, the Minipro programmer software reported an incorrect file checksum. After this fix the checksum verification passes

2 Not usable on Windows due to error while reading the .pld file
  * Cause: The code would assume the file size would be equal to the number of characters read, however this is not the case on Windows where CR LF is translated to LF when reading
  * Fix: Use an alternative way to calculate file size (by opening file and reading all the characters) - this is not the most efficient fix bug adequate for the small input files this program is designed for, and minimizes the scope of the change. Also, will use correct line endings on Windows (previously would have produced CR LF LF as line endings due to the translation by Windows of CR into CR LF.
  * Verification: After this fix, I was able to compile .pld files to .jed files successfully on Windows (code built using Mingw-64.)

3 Checksums were not wrapping from 65535 (0xffff) to 0 per the JEDEC specs. See [here] (http://www.pldtool.com/pdf/jesd3c_jedecfmt.pdf) on page 4
  * Cause: Checksum was using a signed int with no modulo operator. This is not just theoretical since a fully populated set of fuse rows should exceed 65535 on the checksum.
  * Fix: Implemented the algorithm per the document: "The transmission checksum is the 16-bit sum (i.e. modulo 65,535) of all ASCII characters transmitted between and including the STX and ETX". Also made sure that additions to the checksum were using unsigned data types. (At least the checksums should be correct if char is signed)
  * Verification: Checksum still matches for the smaller examples. I have not done a test on a large set of fuse data, but the code is straightforward:   sum = (sum + N) % 0x10000
  
     