### PR TITLE
Fix feedback support in simple mode (mode 1)

### DIFF
--- a/src/galasm.c
+++ b/src/galasm.c
@@ -543,7 +543,7 @@ int AssemblePldFile(char *file, struct Config *cfg)
                                       /* then use automatically mode 2      */
                     for (n = 0; n < 8; n++)
                     {
-                        if (OLMC[n].PinType == INPUT)
+                        if (OLMC[n].PinType == INPUT || (OLMC[n].PinType == COM_TRI_OUT && OLMC[n].FeedBack))
                         {
                             if (gal_type == GAL16V8)
                             {
@@ -574,18 +574,6 @@ int AssemblePldFile(char *file, struct Config *cfg)
                                     break;
                                 }
                             }
-                        }
-
-                        /* output and feedback? then mode 2 */
-
-                        if (OLMC[n].PinType == COM_TRI_OUT && OLMC[n].FeedBack)
-                        {
-                            modus = MODE2;      /* mode 2 */
-
-                            Jedec.GALSYN = 1;   /* set SYN,  AC0 bit */
-                            Jedec.GALAC0 = 1;
-
-                            break;
                         }
                     }
                 }

--- a/src/galasm.c
+++ b/src/galasm.c
@@ -510,6 +510,9 @@ int AssemblePldFile(char *file, struct Config *cfg)
                 {
                     if (OLMC[n].PinType == REGOUT) /* is there a registered  */
                     {                              /* OLMC?, then GAL's mode */
+                        if (cfg->Verbose) {
+                            printf("OLMC[%d] is configured as registered output, using registered mode (3)\n", n);
+                        }
                         modus = MODE3;             /* is mode 3              */
 
                         Jedec.GALSYN = 0;      /* set SYN and AC0 for mode 3 */
@@ -526,6 +529,9 @@ int AssemblePldFile(char *file, struct Config *cfg)
                     {
                         if (OLMC[n].PinType == TRIOUT) /* is there a tristate */
                         {                              /* OLMC?, then GAL's   */
+                            if (cfg->Verbose) {
+                                printf("OLMC[%d] is configured as tri-state output, using complex mode (2)\n", n);
+                            }
                             modus = MODE2;             /* mode is mode 2      */
 
                             Jedec.GALSYN = 1;      /* set SYN, AC0 for mode 2 */
@@ -551,6 +557,11 @@ int AssemblePldFile(char *file, struct Config *cfg)
 
                                 if (pin_num == 15 || pin_num == 16)
                                 {
+			            if (cfg->Verbose) {
+                                        printf("Pin %d is configured as %s, using complex mode (2)\n",
+                                                pin_num,
+                                                OLMC[n].PinType == INPUT ? "input" : "output with feedback");
+                                    }
                                     modus = MODE2;      /* mode 2 */
 
                                     Jedec.GALSYN = 1;   /* set SYN, AC0 bit */
@@ -566,6 +577,11 @@ int AssemblePldFile(char *file, struct Config *cfg)
 
                                 if (pin_num == 18 || pin_num == 19)
                                 {
+			            if (cfg->Verbose) {
+                                        printf("Pin %d is configured as %s, using complex mode (2)\n",
+                                                pin_num,
+                                                OLMC[n].PinType == INPUT ? "input" : "output with feedback");
+                                    }
                                     modus = MODE2;      /* mode 2 */
 
                                     Jedec.GALSYN = 1;   /* set SYN, AC0 bit */
@@ -580,6 +596,9 @@ int AssemblePldFile(char *file, struct Config *cfg)
 
                 if (!modus)             /* if there is still no mode */
                 {                       /* defined, use mode 1 */
+	            if (cfg->Verbose) {
+                        printf("Defaulting to simple mode (1)\n");
+                    }
                     modus = MODE1;
 
                     Jedec.GALSYN = 1;       /* set SYN and AC0 bit */
@@ -2311,6 +2330,7 @@ int main(int argc, char *argv[])
 	cfg.JedecSecBit 	= FALSE;
 	cfg.JedecFuseChk 	= FALSE;
 	cfg.ForceCRLF		= FALSE;
+	cfg.Verbose		= FALSE;
 
 	p = argv[1];
 
@@ -2352,17 +2372,22 @@ int main(int argc, char *argv[])
 			case 'W':
 				cfg.ForceCRLF = TRUE;
 			break;
+			case 'v':
+			case 'V':
+				cfg.Verbose = TRUE;
+				break;
 
 			case 'h':
 			case 'H':
 			case '?':
-				printf("Usage:\nGALasm [-scfpaw] <filename>\n");
+				printf("Usage:\nGALasm [-scfpawv] <filename>\n");
 				printf(	"-s Enable security fuse\n"
 						"-c Do not create the .chp file\n"
 						"-f Do not create the .fus file\n"
 						"-p Do not create the .pin file\n"
 						"-a Restrict checksum to the fuse array only\n"
-						"-w Force <CR><LF> line endings for .jed file overriding platform default\n");
+						"-w Force <CR><LF> line endings for .jed file overriding platform default\n"
+						"-v Verbose output\n");
 				return(0);
 
       		case '-': 

--- a/src/galasm.h
+++ b/src/galasm.h
@@ -166,6 +166,7 @@ struct  Config
     BOOL JedecSecBit;      /* set security bit in JEDEC? */
     BOOL JedecFuseChk;     /* calc. fuse checksum?       */ /* azummo: if false, file checksum will be generated */
     BOOL ForceCRLF;        /* windows line endings?      */
+    BOOL Verbose;          /* verbose output */
 };
 
 

--- a/src/galasm.h
+++ b/src/galasm.h
@@ -261,6 +261,8 @@ void  IncPointer(struct ActBuffer *buff);
 void  DecPointer(struct ActBuffer *buff);
 void  FreeBuffer(struct Buffer *buff);
 char *GetGALName(int galtype);
+char *GetPinName(UBYTE *pinnames, int pinnum);
+char *GetModeName(int mode);
 void  ErrorReq(int errornum);
 
 /* Jedec.c */

--- a/src/support.c
+++ b/src/support.c
@@ -304,6 +304,43 @@ char *GetGALName(int galtype)
 }
 
 /******************************************************************************
+** GetPinName()
+*******************************************************************************
+** input:   *pinnames  pointer to the pinnames array
+**          pinnum     the number of the pin
+**
+** output:  pointer to a string with the pin name
+**
+******************************************************************************/
+
+char *GetPinName(UBYTE *pinnames, int pinnum)
+{
+	return (char*) (pinnames + (pinnum - 1) * 10);
+}
+
+/******************************************************************************
+** GetModeName()
+*******************************************************************************
+** input:   mode
+**
+** output:  pointer to a string with the mode name
+**
+******************************************************************************/
+
+char *GetModeName(int mode)
+{
+	switch(mode)
+	{
+		case MODE1:	return("simple");
+		case MODE2:	return("complex");
+		case MODE3:	return("registered");
+
+		default:
+				return "UNKNOWN";
+	}
+}
+
+/******************************************************************************
 ** errorReq()
 *******************************************************************************
 ** input:   error number


### PR DESCRIPTION
This patch fixes the feedback support in simple mode (mode 1) and addresses https://github.com/daveho/GALasm/issues/12
When configured in simple mode:

- GAL16V8 supports feedback on all OLMC cells except of ones connected to pin 15 and 16
- GAL20V8 supports feedback on all OLMC cells except of ones connected to pin 18 and 19

This patch removes the check that forces complex mode (mode 2) if one of the output pins is used for feedback.
It adds a check for the simple mode output-only pins listed above, so that if they are used for feedback, galasm will use complex mode (mode 2)